### PR TITLE
Replace `finl_unicode` with `unicode-properties`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,5 @@ repository = "https://github.com/sfackler/rust-stringprep"
 readme = "README.md"
 
 [dependencies]
-finl_unicode = "1.2.0"
 unicode-bidi = "0.3"
 unicode-normalization = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ readme = "README.md"
 [dependencies]
 unicode-bidi = "0.3"
 unicode-normalization = "0.1"
+unicode-properties = "0.1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,9 @@
 //!
 //! [RFC 3454]: https://tools.ietf.org/html/rfc3454
 #![warn(missing_docs)]
-extern crate finl_unicode;
 extern crate unicode_bidi;
 extern crate unicode_normalization;
 
-use finl_unicode::categories::CharacterCategories;
 use std::borrow::Cow;
 use std::fmt;
 use unicode_normalization::UnicodeNormalization;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,12 @@
 #![warn(missing_docs)]
 extern crate unicode_bidi;
 extern crate unicode_normalization;
+extern crate unicode_properties;
 
 use std::borrow::Cow;
 use std::fmt;
 use unicode_normalization::UnicodeNormalization;
+use unicode_properties::{GeneralCategoryGroup, UnicodeGeneralCategory};
 
 mod rfc3454;
 pub mod tables;
@@ -351,7 +353,7 @@ pub fn x520prep(s: &str, case_fold: bool) -> Result<Cow<'_, str>, Error> {
     // "The first code point of a string is prohibited from being a combining character."
     match s.chars().next() {
         Some(c) => {
-            if c.is_mark() {
+            if c.general_category_group() == GeneralCategoryGroup::Mark {
                 return Err(Error(ErrorCause::StartsWithCombiningCharacter));
             }
         }

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -1,5 +1,4 @@
 //! Character Tables
-use finl_unicode::categories::CharacterCategories;
 use std::cmp::Ordering;
 use std::str::Chars;
 use unicode_bidi::{bidi_class, BidiClass};

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -2,6 +2,7 @@
 use std::cmp::Ordering;
 use std::str::Chars;
 use unicode_bidi::{bidi_class, BidiClass};
+use unicode_properties::{GeneralCategoryGroup, UnicodeGeneralCategory};
 
 use super::rfc3454;
 
@@ -245,6 +246,6 @@ pub fn x520_mapped_to_nothing(c: char) -> bool {
 pub fn x520_mapped_to_space(c: char) -> bool {
     match c {
         '\u{09}' | '\u{0A}'..='\u{0D}' | '\u{85}' => true,
-        _ => c.is_separator(),
+        _ => c.general_category_group() == GeneralCategoryGroup::Separator,
     }
 }


### PR DESCRIPTION
We are trying to package this project on Fedora, but we are encountering some licensing issues with `finl_unicode` packaging. Digging a bit deeper I find it odd that this package would be dependent on `finl` package. Trying to remove this dependence, I've found that there are only 2 functions that are actually used, and I would like to ask for some feedback if these could be replaced with some more standard functions