### PR TITLE
Make this crate no_std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,36 @@ jobs:
           key: clippy-target-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}y
       - run: cargo clippy --all --all-targets
 
-  test:
-    name: test
+  test-no_std:
+    name: test no_std on Rust 1.81.0
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: sfackler/actions/rustup@master
+        with:
+          version: 1.81.0
+      - run: echo "version=$(rustc --version)" >> $GITHUB_OUTPUT
+        id: rust-version
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry/index
+          key: index-${{ runner.os }}-${{ github.run_number }}
+          restore-keys: |
+            index-${{ runner.os }}-
+      - run: cargo generate-lockfile
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry/cache
+          key: registry-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}
+      - run: cargo fetch
+      - uses: actions/cache@v3
+        with:
+          path: target
+          key: test-target-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}y
+      - run: cargo test --all
+
+  test-std:
+    name: test std on Rust 1.56.0
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -73,4 +101,4 @@ jobs:
         with:
           path: target
           key: test-target-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}y
-      - run: cargo test --all
+      - run: cargo test --all --features=std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/sfackler/rust-stringprep"
 readme = "README.md"
 
 [dependencies]
-unicode-bidi = "0.3"
-unicode-normalization = "0.1"
-unicode-properties = "0.1.1"
+unicode-bidi = { version = "0.3", default-features = false, features = ["hardcoded-data"] }
+unicode-normalization = { version = "0.1", default-features = false }
+unicode-properties = { version = "0.1.1", default-features = false, features = ["general-category"] }
+
+[features]
+std = ["unicode-bidi/std", "unicode-normalization/std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,19 @@
 //! An implementation of the "stringprep" algorithm defined in [RFC 3454][].
 //!
 //! [RFC 3454]: https://tools.ietf.org/html/rfc3454
+#![no_std]
 #![warn(missing_docs)]
+extern crate alloc;
 extern crate unicode_bidi;
 extern crate unicode_normalization;
 extern crate unicode_properties;
 
-use std::borrow::Cow;
-use std::fmt;
+#[cfg(feature = "std")]
+extern crate std;
+
+use alloc::borrow::Cow;
+use alloc::string::String;
+use core::fmt;
 use unicode_normalization::UnicodeNormalization;
 use unicode_properties::{GeneralCategoryGroup, UnicodeGeneralCategory};
 
@@ -44,7 +50,12 @@ impl fmt::Display for Error {
     }
 }
 
+// This is only needed for Rust versions older than 1.81.0, before core::error::Error got
+// stabilized.
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}
+#[cfg(not(feature = "std"))]
+impl core::error::Error for Error {}
 
 /// Prepares a string with the SASLprep profile of the stringprep algorithm.
 ///

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -1,6 +1,6 @@
 //! Character Tables
-use std::cmp::Ordering;
-use std::str::Chars;
+use core::cmp::Ordering;
+use core::str::Chars;
 use unicode_bidi::{bidi_class, BidiClass};
 use unicode_properties::{GeneralCategoryGroup, UnicodeGeneralCategory};
 


### PR DESCRIPTION
As nothing actually depends on `std`, there is no need to keep a dependency on it.  This allows users such as the [jid](https://docs.rs/jid) crate to actually be `no_std` as well.